### PR TITLE
Fix pass inlet stream name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,8 @@
 # About ofxLSL
 
 #### ofApp Usage
-- ofxLSL searches for streams based on resInletInfo
-- resInletInfo must be in the form of a proper resolvestreams() argument, given in a below section
-- This is a static variable that should be set in the main.cpp of ofApp in the following format:
-
-   `const char * ofxLSL::resInletInfo = "name = 'CFL'";`
-   
-- If using the Python Marker Code, the default stream name is CFL
+- The user can provide the stream name they are looking for as a parameter to `lsl.start()` in `ofApp::setup()`
+- If using the Python Marker Code (marker.py in the markerTest directory), the default stream name is `DataSyncMarker`
 
 #### Dependency
 - In order to run the example, liblsl64.dll must be in the app bin folder with the compiled .exe
@@ -28,31 +23,5 @@
   - same basic function as Marker.py
   - writes the timestamps of the tags to an external file, _sentInfo.csv_
 - These files can be used to test the basic functionality of ofxLSL in recieving string tags from a single stream
-- Names of the streams are currently set to "CFL", but can be changed to suit needs
-- _**NOTE:**_ ofxLSL can find a stream based on any resolve stream argument shown in the next section
-  - Whatever is used to sort **must match resInletInfo set in the main of ofApp**
-  
+- Names of the streams are currently set to "DataSyncMarker", but can be changed to suit needs
 
-#### resolvestreams() arguments
-- **name**
-  - Name of the stream. Describes the device (or product series) that this stream makes available (for use by programs, experimenters or data analysts)
-  - Cannot be empty.
-- **type**
-  - Content type of the stream
-  - By convention LSL uses the content types defined in the XDF file format specification where applicable (https://github.com/sccn/xdf).
-  - The content type is the preferred way to find streams (as opposed to searching by name).
-- **channel_count** 
-  - Number of channels per sample. This stays constant for the lifetime of the stream.
-  - default = 1
-- **nominal_srate**
-  - The sampling rate (in Hz) as advertised by the data source, regular (otherwise set to IRREGULAR_RATE).
-  - default = IRREGULAR_RATE
-- **channel_format**
-  - Format/type of each channel. If your channels have different formats, consider supplying multiple streams or use the largest type that can hold  them all (such as cf_double64). 
-  - Passed as a string, without the cf_ prefix,
-    - e.g., 'float32' (default cf_float32)
-- **source_id**
-  - Unique identifier of the device or source of the data, if available (such as the serial number).
-  - Critical for system robustness since it allows recipients to recover from failure even after the serving app, device or computer crashes (just by finding a stream with the same source id on the network again).
-  - Highly recommended to always try to provide whatever information can uniquely identify the data source itself.
-  - default = ''

--- a/example/LSL_Example/src/main.cpp
+++ b/example/LSL_Example/src/main.cpp
@@ -1,7 +1,7 @@
 #include "ofMain.h"
 #include "ofApp.h"
 
-const char * ofxLSL::resInletInfo = "name = 'CFL'";
+//const char * ofxLSL::resInletInfo = "name = 'CFL'";
 //========================================================================
 int main() {
 	ofSetupOpenGL(1024, 768, OF_WINDOW);			// <-------- setup the GL context

--- a/example/LSL_Example/src/main.cpp
+++ b/example/LSL_Example/src/main.cpp
@@ -1,7 +1,7 @@
 #include "ofMain.h"
 #include "ofApp.h"
 
-//const char * ofxLSL::resInletInfo = "name = 'CFL'";
+
 //========================================================================
 int main() {
 	ofSetupOpenGL(1024, 768, OF_WINDOW);			// <-------- setup the GL context

--- a/example/LSL_Example/src/ofApp.cpp
+++ b/example/LSL_Example/src/ofApp.cpp
@@ -5,7 +5,7 @@ void ofApp::setup() {
 	ofLogToConsole();
 	ofLogLevel(OF_LOG_VERBOSE);
 	ofLogNotice() << "Starting";
-	lsl.start("EmotiBit");
+	lsl.start("DataSyncMarker");
 
 }
 

--- a/example/LSL_Example/src/ofApp.cpp
+++ b/example/LSL_Example/src/ofApp.cpp
@@ -2,6 +2,7 @@
 
 //--------------------------------------------------------------
 void ofApp::setup() {
+	ofLogToConsole();
 	ofLogNotice() << "Starting";
 	lsl.start();
 

--- a/example/LSL_Example/src/ofApp.cpp
+++ b/example/LSL_Example/src/ofApp.cpp
@@ -3,14 +3,15 @@
 //--------------------------------------------------------------
 void ofApp::setup() {
 	ofLogToConsole();
+	ofLogLevel(OF_LOG_VERBOSE);
 	ofLogNotice() << "Starting";
-	lsl.start();
+	lsl.start("name = 'EmotiBit'");
 
 }
 
 //--------------------------------------------------------------
 void ofApp::update() {
-	ofLogLevel(OF_LOG_VERBOSE);
+	
 	//ofLogNotice() << "Updating";
 //	if (lsl.isConnected()) {
 	auto buffer = lsl.flush();

--- a/example/LSL_Example/src/ofApp.cpp
+++ b/example/LSL_Example/src/ofApp.cpp
@@ -5,7 +5,7 @@ void ofApp::setup() {
 	ofLogToConsole();
 	ofLogLevel(OF_LOG_VERBOSE);
 	ofLogNotice() << "Starting";
-	lsl.start("name = 'EmotiBit'");
+	lsl.start("EmotiBit");
 
 }
 

--- a/markerTest/py/marker.py
+++ b/markerTest/py/marker.py
@@ -17,7 +17,7 @@ from pylsl import StreamInfo, StreamOutlet
 def main():
     """Alternate printing 'Hello' and 'World' and send a trigger each time."""
     # Set up LabStreamingLayer stream.
-    info = StreamInfo(name='EmotiBit', type='Tags', channel_count=1,
+    info = StreamInfo(name='DataSyncMarker', type='Tags', channel_count=1,
                       channel_format='string', source_id='')
     outlet = StreamOutlet(info)  # Broadcast the stream.
 

--- a/markerTest/py/marker.py
+++ b/markerTest/py/marker.py
@@ -17,7 +17,7 @@ from pylsl import StreamInfo, StreamOutlet
 def main():
     """Alternate printing 'Hello' and 'World' and send a trigger each time."""
     # Set up LabStreamingLayer stream.
-    info = StreamInfo(name='CFL', type='Tags', channel_count=1,
+    info = StreamInfo(name='EmotiBit', type='Tags', channel_count=1,
                       channel_format='string', source_id='')
     outlet = StreamOutlet(info)  # Broadcast the stream.
 

--- a/markerTest/py/marker.py
+++ b/markerTest/py/marker.py
@@ -40,7 +40,7 @@ def main():
     hello = visual.TextStim(win, text="Hello")
     world = visual.TextStim(win, text="World")
 
-    for i in range(200):
+    for i in range(200000):
         if not i % 2:  # If i is even:
             hello.draw()
             # # Experiment with win.callOnFlip method. See Psychopy window docs.

--- a/src/ofxLSL.cpp
+++ b/src/ofxLSL.cpp
@@ -2,9 +2,12 @@
 
 ofxLSL::ofxLSL() : active(false) {}
 
+std::string ofxLSL::getFormattedStreamName(std::string streamName) {
+	return ("name= '" + streamName + "'");
+}
 bool ofxLSL::start(std::string streamName) {
 	if(active) return false;
-	inletStream = streamName;
+	_inletStream = getFormattedStreamName(streamName);
 	thread = std::make_unique<std::thread>(&ofxLSL::update, this);
 	active = true;
 	return true;
@@ -55,7 +58,7 @@ void ofxLSL::disconnect() {
 
 void ofxLSL::connect() {
 	//auto streams = lsl::resolve_stream("desc/correlation", "R", 1, 2.f);
-	auto streams = lsl::resolve_stream(inletStream, 1, 1);
+	auto streams = lsl::resolve_stream(_inletStream, 1, 1);
 	if (streams.size() == 0) {
 		ofLogNotice() << "No Streams Found";
 		return;
@@ -87,7 +90,7 @@ void ofxLSL::connect() {
 				} } } }
 	
 	//auto Qstreams = lsl::resolve_stream("desc/correlation", "Stability", 1, 2.f);
-	auto Qstreams = lsl::resolve_stream(inletStream);
+	auto Qstreams = lsl::resolve_stream(_inletStream);
 	std::vector<lsl::stream_info> resolvedStreams = lsl::resolve_streams(1.0);
 	
 	stabilities.clear();

--- a/src/ofxLSL.cpp
+++ b/src/ofxLSL.cpp
@@ -2,8 +2,9 @@
 
 ofxLSL::ofxLSL() : active(false) {}
 
-bool ofxLSL::start() {
+bool ofxLSL::start(std::string streamName) {
 	if(active) return false;
+	inletStream = streamName;
 	thread = std::make_unique<std::thread>(&ofxLSL::update, this);
 	active = true;
 	return true;
@@ -54,7 +55,7 @@ void ofxLSL::disconnect() {
 
 void ofxLSL::connect() {
 	//auto streams = lsl::resolve_stream("desc/correlation", "R", 1, 2.f);
-	auto streams = lsl::resolve_stream(resInletInfo, 1, 1);
+	auto streams = lsl::resolve_stream(inletStream, 1, 1);
 	if (streams.size() == 0) {
 		ofLogNotice() << "No Streams Found";
 		return;
@@ -86,7 +87,7 @@ void ofxLSL::connect() {
 				} } } }
 	
 	//auto Qstreams = lsl::resolve_stream("desc/correlation", "Stability", 1, 2.f);
-	auto Qstreams = lsl::resolve_stream(resInletInfo);
+	auto Qstreams = lsl::resolve_stream(inletStream);
 	std::vector<lsl::stream_info> resolvedStreams = lsl::resolve_streams(1.0);
 	
 	stabilities.clear();

--- a/src/ofxLSL.h
+++ b/src/ofxLSL.h
@@ -26,12 +26,13 @@ struct ofxStability {
 
 class ofxLSL : public ofThread {
 	
+	std::string _inletStream;
 public:
-	std::string inletStream;
 	ofxLSL();
 	~ofxLSL() { stop(); };
 	
 	bool start(std::string streamName);
+	std::string getFormattedStreamName(std::string streamName);
 	bool stop();
 	bool isConnected() {
 		std::lock_guard<std::mutex> lock(mutex);

--- a/src/ofxLSL.h
+++ b/src/ofxLSL.h
@@ -31,7 +31,7 @@ public:
 	ofxLSL();
 	~ofxLSL() { stop(); };
 	
-	bool start(std::string streamName = "EmotiBit");
+	bool start(std::string streamName);
 	bool stop();
 	bool isConnected() {
 		std::lock_guard<std::mutex> lock(mutex);

--- a/src/ofxLSL.h
+++ b/src/ofxLSL.h
@@ -27,12 +27,11 @@ struct ofxStability {
 class ofxLSL : public ofThread {
 	
 public:
-	static const char * resInletInfo;
-
+	std::string inletStream;
 	ofxLSL();
 	~ofxLSL() { stop(); };
 	
-	bool start();
+	bool start(std::string streamName = "EmotiBit");
 	bool stop();
 	bool isConnected() {
 		std::lock_guard<std::mutex> lock(mutex);

--- a/src/ofxLSL.h
+++ b/src/ofxLSL.h
@@ -26,12 +26,17 @@ struct ofxStability {
 
 class ofxLSL : public ofThread {
 	
-	std::string _inletStream;
+	std::string _inletStream; //!< Name of the inletStream
 public:
 	ofxLSL();
 	~ofxLSL() { stop(); };
 	
 	bool start(std::string streamName);
+	/*!
+	@brief function to convert stream name into a format accepted by LSL 
+	@param streamName inlet stream name
+	@return stream name formatted to LSL format
+	*/
 	std::string getFormattedStreamName(std::string streamName);
 	bool stop();
 	bool isConnected() {


### PR DESCRIPTION
# Description
- The inlet marker stream anme can now be passed in through the `lsl.start()` function

# issues
- closes #1 